### PR TITLE
Updated readme to remove reference to Parcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The default template project for [nano-react-app](https://github.com/nano-react-
 
 ## Typechecking
 
-Unforunately, Parcel does not perform typechecking. So you will need to make use of the `typecheck` and `typewatch` scripts above.
+Unfortunately, ViteJS does not perform typechecking. So you will need to make use of the `typecheck` and `typewatch` scripts above.
 
 ## Custom port
 


### PR DESCRIPTION
Minor update to readme to remove reference to ParcelJS that's not used any more.