### PR TITLE
Add tilde remapping to allow quicker startup in vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^18.0.8",
         "babel-preset-nano-react-app": "^0.1.0",
         "typescript": "^4.8.4",
-        "vite": "^3.2.1"
+        "vite": "^3.2.1",
+        "vite-tsconfig-paths": "^4.2.0"
     }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
+export default defineConfig({
+    plugins:[
+        tsconfigPaths()
+    ]
+});


### PR DESCRIPTION
In tsconfig, there is a path remapping from "./" to "\~". This means that vscode autocomplete will resolve import paths to "\~/path/to/file", which vite does not recognise. 

I attempted to remove the path remapping, however, this causes vscode autocomplete to not append any prefix at all, which causes a different error.

Therefore, this PR adds vite..config.ts to the project with the remapping from ~ to ./, thereby allowing autocomplete to work without further modifications. However, this adds a dependency on vite-tsconfig-paths.